### PR TITLE
Added Json parser to extract module paths from json file

### DIFF
--- a/orchestrator.go
+++ b/orchestrator.go
@@ -3,34 +3,17 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/trilogy-group/cloudfix-linter/logger"
 )
 
 func main() {
-	_, err := extractModulePaths("sample.json")
-	if err != nil {
-		fmt.Println("Could not Extract module names:- ", err)
-		return
-	}
+	//modulePaths := extractModulePaths(jsonString)
 }
 
-func extractModulePaths(fileName string) ([]string, error) {
-	var emptyArray []string
+func extractModulePaths(jsonString string) []string {
 	appLogger := logger.New()
-	jsonFile, err := os.Open(fileName)
-	if err != nil {
-		appLogger.Error().Println("Error occurred while opening json file containing module names in orchestrator")
-		return emptyArray, err
-	}
-	defer jsonFile.Close()
-	byteValue, err := ioutil.ReadAll(jsonFile)
-	if err != nil {
-		appLogger.Error().Println("Error occurred while Reading from json file containing module names in orchestrator")
-		return emptyArray, err
-	}
+	byteValue := []byte(jsonString)
 	/*
 		Initialising a variable result which stores the data in the format of defined structure.
 		Structure: "map(key->string,value->(array of map(key->string,value->interface))"
@@ -42,5 +25,6 @@ func extractModulePaths(fileName string) ([]string, error) {
 	for key, element := range result["issues"] {
 		modulePaths[key] = fmt.Sprint(element["message"])
 	}
-	return modulePaths, nil
+	appLogger.Info().Println("Successfully extracted module paths from json string containing module paths")
+	return modulePaths
 }

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -7,24 +7,26 @@ import (
 	"github.com/trilogy-group/cloudfix-linter/logger"
 )
 
-func main() {
-	//modulePaths := extractModulePaths(jsonString)
-}
-
-func extractModulePaths(jsonString string) []string {
+func extractModulePaths(jsonString string) ([]string, error) {
 	appLogger := logger.New()
+	var modulePaths []string
 	byteValue := []byte(jsonString)
 	/*
 		Initialising a variable result which stores the data in the format of defined structure.
 		Structure: "map(key->string,value->(array of map(key->string,value->interface))"
 	*/
 	var result map[string][]map[string]interface{}
-	json.Unmarshal([]byte(byteValue), &result)
+	err := json.Unmarshal([]byte(byteValue), &result)
+	if err != nil {
+		appLogger.Error().Println("Failed to unmarshall module paths from json string")
+		return modulePaths, err
+	}
+	appLogger.Info().Println("Unmarshalled module paths succesfully!")
 	noOfModules := len(result["issues"])
-	modulePaths := make([]string, noOfModules)
+	modulePaths = make([]string, noOfModules)
 	for key, element := range result["issues"] {
 		modulePaths[key] = fmt.Sprint(element["message"])
 	}
-	appLogger.Info().Println("Successfully extracted module paths from json string containing module paths")
-	return modulePaths
+	appLogger.Info().Println("Extracted module paths succesfully!")
+	return modulePaths, nil
 }

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -1,1 +1,46 @@
+package main
 
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/trilogy-group/cloudfix-linter/logger"
+)
+
+func main() {
+	_, err := extractModulePaths("sample.json")
+	if err != nil {
+		fmt.Println("Could not Extract module names:- ", err)
+		return
+	}
+}
+
+func extractModulePaths(fileName string) ([]string, error) {
+	var emptyArray []string
+	appLogger := logger.New()
+	jsonFile, err := os.Open(fileName)
+	if err != nil {
+		appLogger.Error().Println("Error occurred while opening json file containing module names in orchestrator")
+		return emptyArray, err
+	}
+	defer jsonFile.Close()
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		appLogger.Error().Println("Error occurred while Reading from json file containing module names in orchestrator")
+		return emptyArray, err
+	}
+	/*
+		Initialising a variable result which stores the data in the format of defined structure.
+		Structure: "map(key->string,value->(array of map(key->string,value->interface))"
+	*/
+	var result map[string][]map[string]interface{}
+	json.Unmarshal([]byte(byteValue), &result)
+	noOfModules := len(result["issues"])
+	modulePaths := make([]string, noOfModules)
+	for key, element := range result["issues"] {
+		modulePaths[key] = fmt.Sprint(element["message"])
+	}
+	return modulePaths, nil
+}


### PR DESCRIPTION
1. Added "extractModulePaths()" function to "orchestrator.go" file which takes JSON file name containing module paths as inputs and extracts module paths from it.
2. Format in which parser returns module paths: Array of strings ( Where module paths are present as strings).

Structure of JSON file:- 
{
     "issues": [ ] {"rules": { } ,"message": "modulePath"  ,"range": { }, "callers" :[ ] } ,    
     "errors": [ ]
}
Explanation:- 
For every index in "issues" we get the structure defined after it above ( {"rules:{ } .......}) .
We extract  "message" from every index of array which is the module path and store in final module paths array to be returned.

Design: Not required