### PR TITLE
Added structures for parsing reccos json

### DIFF
--- a/orchestrator.go
+++ b/orchestrator.go
@@ -1,11 +1,19 @@
 package main
 
+import (
+	"encoding/json"
+
+	"github.com/trilogy-group/cloudfix-linter/logger"
+)
+
+//structure for unmarhsalling the Parameters field of the reccomendation output from CLoudFix
 type Parameter struct {
 	IdealType      string `json:"Migrating to instance type"`
 	RecentSnapshot bool   `json:"Has recent snapshot"`
 }
 
-type Response struct {
+//structure for unmarshalling the reccomendation json response from cloudfix
+type ResponseReccos struct {
 	Id                     string
 	Region                 string
 	PrimaryImpactedNodeId  string
@@ -27,4 +35,37 @@ type Response struct {
 	OpportunityDescription string
 	GeneratedDate          string
 	LastUpdatedDate        string
+}
+
+func parseReccos(reccos []byte) map[string]map[string]string {
+	appLogger := logger.New()
+	mapping := map[string]map[string]string{}
+	var responses []ResponseReccos
+	err := json.Unmarshal(reccos, &responses)
+	if err != nil {
+		appLogger.Error().Println("Failed to unmarshall reccomendations")
+		panic(err)
+	}
+	appLogger.Info().Println("Reccomendations unamrshalled succesfully!")
+	//fmt.Println(oppurMap["Ec2IntelToAmd"])
+	for _, recco := range responses {
+		awsID := recco.ResourceId
+		oppurType := recco.OpportunityType
+		temp := map[string]string{}
+		switch oppurType {
+		case "Gp2Gp3":
+			temp["type"] = "gp3"
+			mapping[awsID] = temp
+		case "Ec2IntelToAmd":
+			var idealType = recco.Parameters.IdealType
+			temp["instance_type"] = idealType
+			mapping[awsID] = temp
+		default:
+			appLogger.Warning().Printf("Unknown Oppurtunity Type for resource ID: \"%s\"", awsID)
+			temp["NoAttributeMarker"] = recco.OpportunityDescription
+			mapping[awsID] = temp
+		}
+	}
+	appLogger.Info().Println("Reccomendation mapping made!")
+	return mapping
 }

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -1,1 +1,30 @@
+package main
 
+type Parameter struct {
+	IdealType      string `json:"Migrating to instance type"`
+	RecentSnapshot bool   `json:"Has recent snapshot"`
+}
+
+type Response struct {
+	Id                     string
+	Region                 string
+	PrimaryImpactedNodeId  string
+	OtherImpactedNodeIds   []string
+	ResourceId             string
+	ResourceName           string
+	Difficulty             int
+	Risk                   int
+	ApplicationEnvironment string
+	AnnualSavings          float32
+	AnnualCost             float32
+	Status                 string
+	Parameters             Parameter
+	TemplateApproved       bool
+	CustomerId             int
+	AccountId              string
+	AccountNickname        string
+	OpportunityType        string
+	OpportunityDescription string
+	GeneratedDate          string
+	LastUpdatedDate        string
+}


### PR DESCRIPTION
Design: This function would take in the recommendation json output from cloudfix as input, and would give out a mapping as output. This mapping would then be sent to the persistence manager for storage.
Strcture of the mapping: 

AWSID -> [Attribute Type -> Attribute Value]

The parsing would have to be on the basis of the opportunity type of the recommendation. In case an unknown opportunity type is encountered, then the attribute type field would be filled by "NoAttributeMarker" and the attribute value would be filled by the opportunity description. Otherwise, the two fields would be filled in as their names suggest.

Definition of done: Self-explanatory--the mapping should be successfully made.

Pending work: Currently the sample outputs of only two opportunity types are known. The sample outputs for other types have been requested. As and when we received these samples, the function would be updated.