### PR TITLE
Outline of orchestrator.go file

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,6 +1,9 @@
 package logger
 
 import (
+	"fmt"
+
+	"github.com/google/uuid"
 	"github.com/rifflock/lfshook"
 	"github.com/sirupsen/logrus"
 )
@@ -11,15 +14,30 @@ func NewLogger() *logrus.Logger {
 	if Log != nil {
 		return Log
 	}
-
-	pathMap := lfshook.PathMap{
-		logrus.InfoLevel:  "/logs/console.log",
-		logrus.ErrorLevel: "/logs/console.log",
-		logrus.TraceLevel: "/logs/console.log",
-		logrus.DebugLevel: "/logs/console.log",
+	var flag string
+	var filePath string
+	fmt.Println("Enter Path to log debug files: (Y/N)")
+	fmt.Scan(&flag)
+	if flag == "N" {
+		id := uuid.New().String()
+		filePath = "debug/Track-" + id + ".log"
+		fileName := "Track-" + id + ".log"
+		fmt.Printf("New File \"%s\" created in debug folder\n", fileName)
+	} else {
+		fmt.Scan(&filePath)
 	}
-
+	pathMap := lfshook.PathMap{
+		logrus.InfoLevel:  filePath,
+		logrus.ErrorLevel: filePath,
+		logrus.TraceLevel: filePath,
+		logrus.DebugLevel: filePath,
+		logrus.PanicLevel: filePath,
+		logrus.WarnLevel:  filePath,
+		logrus.FatalLevel: filePath,
+	}
 	Log = logrus.New()
+	Log.SetReportCaller(true)
+	Log.SetLevel(logrus.TraceLevel)
 	Log.Hooks.Add(lfshook.NewHook(
 		pathMap,
 		&logrus.JSONFormatter{},

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,60 +1,28 @@
 package logger
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"time"
+	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
 )
 
-/* Instruction to use logger:-
-   Import ("github.com/trilogy-group/cloudfix-linter/logger") in your go file which is to be logged.
+var Log *logrus.Logger
 
-   Initialise logger in your main function of go file using "appLogger := logger.New()"
-   After this a logs folder would be created if not present
-
-   Writing to the log file using logger:
-   To log info to the logger:- "appLogger.Info().Println("message")"
-   To log Warning to the logger:- "appLogger.Warning().Println("message")"
-   To log Error to the logger:- "appLogger.Error().Println("message")"
-
-   results would get stored in logs/day-month-year.log files
-*/
-const (
-	LogsDirpath = "logs"
-)
-
-type LogDir struct {
-	LogDirectory string
-}
-
-func New() *LogDir {
-	err := os.Mkdir(LogsDirpath, 0666)
-	if err != nil {
-		return nil
+func NewLogger() *logrus.Logger {
+	if Log != nil {
+		return Log
 	}
-	return &LogDir{
-		LogDirectory: LogsDirpath,
+
+	pathMap := lfshook.PathMap{
+		logrus.InfoLevel:  "/logs/console.log",
+		logrus.ErrorLevel: "/logs/console.log",
+		logrus.TraceLevel: "/logs/console.log",
+		logrus.DebugLevel: "/logs/console.log",
 	}
-}
 
-func SetLogFile() *os.File {
-	year, month, day := time.Now().Date()
-	fileName := fmt.Sprintf("%v-%v-%v.log", day, month.String(), year)
-	filePath, _ := os.OpenFile(LogsDirpath+"/"+fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-	return filePath
-}
-func (l *LogDir) Info() *log.Logger {
-	getFilePath := SetLogFile()
-	return log.New(getFilePath, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-}
-
-func (l *LogDir) Warning() *log.Logger {
-	getFilePath := SetLogFile()
-	return log.New(getFilePath, "WARNING: ", log.Ldate|log.Ltime|log.Lshortfile)
-}
-
-func (l *LogDir) Error() *log.Logger {
-	getFilePath := SetLogFile()
-	return log.New(getFilePath, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+	Log = logrus.New()
+	Log.Hooks.Add(lfshook.NewHook(
+		pathMap,
+		&logrus.JSONFormatter{},
+	))
+	return Log
 }

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -3,9 +3,43 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os/exec"
 
 	"github.com/trilogy-group/cloudfix-linter/logger"
 )
+
+func main() {
+
+	//reccosJson:=output(get_reccos(cloudfix credentials)->json)                                    //API call to cloudfix for getting recommendations from cloudfix, has to be decided
+
+	reccosMapping := parseReccos(reccosJson) // Parser generates a map after parsing through json file in map[string]map[string]string format
+
+	store_reccos(reccosMapping) // storing reccos mapping inside the persistor
+
+	IDtoTagsMapping := getIDtoTags() // function returns id to tag mapping in map[string]string format
+
+	store_tagMap(IDtoTagsMapping) //storing id to tag mapping in the persistor
+
+	modulesJsonByte, err := exec.Command("bash", "-c", "tflint only=get_modules -f json").Output() //moduleJsonByte stores the json returned by getmodules rule in tflint in byte format
+	moduleJsonString := string(modulesJsonByte[:])
+
+	modulePaths := extractModulePaths(moduleJsonString) // Function call to extract module paths and store it in an array
+
+	// A file or a data type(array of string/string/ map) has to be initialised here, where all the tflint module calls outputs would be consolidated and then passed to the formatter.
+
+	// Call to tflint root module first,  command:- "tflint . and output stored"                      // Since main.tf file path is not included in module paths
+
+	for _, currentModulePath := range modulePaths {
+		/*
+		   calling tflint for every module path separately
+		   Storing all the outputs in a central place for all the module which will be formatted later and returned to the user
+		*/
+	}
+
+	//finalOutputFormatter()                                                                            // Formates the consolidated output from all the tflint calls to present it to user, input of formatter has to be decided(file or any data structure)
+
+	return
+}
 
 func extractModulePaths(jsonString string) ([]string, error) {
 	appLogger := logger.New()


### PR DESCRIPTION
Here is the outline for all the functions invoked and calls made from the inside of orchestrator.go:-

Sequence of function calls inside orchestrator.go file (input types and commenting done inside code)

-Cloudfix API call to get suggestion.json (Call yet to be decided)
-parseReccos( ):- Parser generates a map after parsing through json file(json string is passed in byte array format) in map[string]map[string]string format
-store_reccos( ):- storing reccos mapping inside the persistor.
-store_tagMap():- storing id to tag mapping in the persistor
-getIDtoTags():- 
            Steps this function covers which are mentioned in sequence diagram separately-
                     1). Calls "terraform state list".
                     2). Gets list of all deployed resources.
                     3). Calls terraform show.
                     4). Gets JSON o/p (containing AWS ID and tags for all resources) 
                     5). Parse json and return Id to tag mapping in map[string]string format.
-Tflint call to get module paths in json format.
-extractModulePaths():- Function call to extract module paths from json and store it in an array.
-Call to root(main.tf) through tflint ( "tflint .")
-Call to each terraform module inside loop.
-Call to output formatter which would format the merged output of all tflint calls and finalize the output which is to be presented to the user.

All the calls related to the orchestrator in the sequence diagram is included in this workflow.
For reference link to sequence diagram:- [shorturl.at/bdgp5](url)


