### PR TITLE
Updated persistance class based on the new design

### DIFF
--- a/orchestrator.go
+++ b/orchestrator.go
@@ -69,3 +69,7 @@ func parseReccos(reccos []byte) map[string]map[string]string {
 	appLogger.Info().Println("Reccomendation mapping made!")
 	return mapping
 }
+
+func getTagToID() map[string]string {
+
+}

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -1,11 +1,19 @@
 package main
 
+import (
+	"encoding/json"
+
+	"github.com/trilogy-group/cloudfix-linter/logger"
+)
+
+//structure for unmarhsalling the Parameters field of the reccomendation output from CLoudFix
 type Parameter struct {
 	IdealType      string `json:"Migrating to instance type"`
 	RecentSnapshot bool   `json:"Has recent snapshot"`
 }
 
-type Response struct {
+//structure for unmarshalling the reccomendation json response from cloudfix
+type ResponseReccos struct {
 	Id                     string
 	Region                 string
 	PrimaryImpactedNodeId  string
@@ -27,4 +35,37 @@ type Response struct {
 	OpportunityDescription string
 	GeneratedDate          string
 	LastUpdatedDate        string
+}
+
+func parseReccos(reccos []byte) map[string]map[string]string {
+	appLogger := logger.New()
+	mapping := map[string]map[string]string{}
+	var responses []ResponseReccos
+	err := json.Unmarshal(reccos, &responses)
+	if err != nil {
+		appLogger.Error().Println("Failed to unmarshall reccomendations")
+		panic(err)
+	}
+	appLogger.Info().Println("Reccomendations unamrshalled succesfully!")
+	//fmt.Println(oppurMap["Ec2IntelToAmd"])
+	for _, recco := range responses {
+		awsID := recco.ResourceId
+		oppurType := recco.OpportunityType
+		temp := map[string]string{}
+		switch oppurType {
+		case "Gp2Gp3":
+			temp["type"] = "gp3"
+			mapping[awsID] = temp
+		case "Ec2IntelToAmd":
+			var idealType = recco.Parameters.IdealType
+			temp["instance_type"] = idealType
+			mapping[awsID] = temp
+		default:
+			appLogger.Warning().Printf("Unknown Oppurtunity Type for resource ID: \"%s\"", awsID)
+			temp["NoAttributeMarker"] = recco.OpportunityDescription
+			mapping[awsID] = temp
+		}
+	}
+	appLogger.Info().Println("Reccomendation mapping made!")
+	return mapping
 }

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -1,1 +1,30 @@
+package main
 
+type Parameter struct {
+	IdealType      string `json:"Migrating to instance type"`
+	RecentSnapshot bool   `json:"Has recent snapshot"`
+}
+
+type Response struct {
+	Id                     string
+	Region                 string
+	PrimaryImpactedNodeId  string
+	OtherImpactedNodeIds   []string
+	ResourceId             string
+	ResourceName           string
+	Difficulty             int
+	Risk                   int
+	ApplicationEnvironment string
+	AnnualSavings          float32
+	AnnualCost             float32
+	Status                 string
+	Parameters             Parameter
+	TemplateApproved       bool
+	CustomerId             int
+	AccountId              string
+	AccountNickname        string
+	OpportunityType        string
+	OpportunityDescription string
+	GeneratedDate          string
+	LastUpdatedDate        string
+}

--- a/persistance.go
+++ b/persistance.go
@@ -1,12 +1,50 @@
 package main
 
+import (
+	"fmt"
+	"os"
+)
+
 type Persistance struct {
+	// No data fields required for this class. Data shall be persisted using the file system
 }
 
-func (p *Persistance) store_reccos(map[string]map[string]string)
+//Member functions for the class follow:
 
-func (p *Persistance) get_reccos() map[string]map[string]string
+func (p *Persistance) store_reccos(reccosMap map[string]map[string]string, fileNameForReccos string) error {
+	file, err := os.Create(fileNameForReccos)
+	if err != nil {
+		//Add error log
+		return err
+	}
+	for key, innerMap := range reccosMap {
+		for innerKey, innerValue := range innerMap {
+			toWrite := fmt.Sprintf("%s:%s:%s\n", key, innerKey, innerValue)
+			_, err := file.WriteString(toWrite)
+			if err != nil {
+				//Add Error Log
+				return err
+			}
+		}
+	}
+	//Add Info Log
+	return nil
+}
 
-func (p *Persistance) store_tagMap(map[string]string)
-
-func (p *Persistance) get_tagMap() map[string]string
+func (p *Persistance) store_tagMap(tagToIDMap map[string]string, fileNameForTagMap string) error {
+	file, err := os.Create(fileNameForTagMap)
+	if err != nil {
+		//Add error log
+		return err
+	}
+	for key, value := range tagToIDMap {
+		toWrite := fmt.Sprintf("%s:%s\n", key, value)
+		_, err := file.WriteString(toWrite)
+		if err != nil {
+			//Add Error Log
+			return err
+		}
+	}
+	//Add Info Log
+	return nil
+}


### PR DESCRIPTION
On the basis of the discussion on the data persistence held today, the getter functions have been removed. TfLint's orchestrator will now be reading data directly from the file, not using the persistence class. 

The store functions (they'll be called by the orchestrator) now also take in the filename to which the data has to be stored as an argument. The orchestrator shall be setting an environment variable with the filename and then calling the persistence manager by passing the same filename. The persistence manager shall be storing the data in that file. TfLlint's orchestrator shall be accessing the filename using the environment variable and then reading the data off of it after appending the filename to the path of the directory from which the orchestrator shall be run. 

The logic of the store functions:

Create a file by the name that has been passed as an argument. Iterate through the map. On a new line, write the fields of the map separated by a comma. For example, if a key-value pair in the map is 123 -> 456
store 123:456 in the file. The logic to write and then subsequently read such a basic format is easy. It will serve our purpose of getting the data to TfLint's orchestrator. Hence, other formats of storage, for example, first marshalling the map into a json string, and then unmarshalling it in TfLint's orchestrator were not explored. Using JSON would anyway have been overkill for such basic data storage as they are just key-value pairs. Multiple fields per object, arrays etc. would not be present.