### PR TITLE
Added New logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module cloudfix-linter
 
 go 1.13
 
-require github.com/hashicorp/terraform-json v0.14.0
+require (
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/terraform-json v0.14.0
+	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module cloudfix-linter
 go 1.13
 
 require (
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-json v0.14.0
-	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5
+	github.com/sirupsen/logrus v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-version v1.5.0 h1:O293SZ2Eg+AAYijkVK3jR786Am1bhDEh2GHT0tIVE5E=
 github.com/hashicorp/go-version v1.5.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e17dKDpqV7s=
@@ -18,8 +20,13 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
+github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
@@ -34,6 +41,8 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,8 +1,7 @@
 package logger
 
 import (
-	"fmt"
-
+	"log"
 	"github.com/google/uuid"
 	"github.com/rifflock/lfshook"
 	"github.com/sirupsen/logrus"
@@ -10,21 +9,15 @@ import (
 
 var Log *logrus.Logger
 
-func NewLogger() *logrus.Logger {
+func NewLogger(filePath string) *logrus.Logger {
 	if Log != nil {
 		return Log
 	}
-	var flag string
-	var filePath string
-	fmt.Println("Enter Path to log debug files: (Y/N)")
-	fmt.Scan(&flag)
-	if flag == "N" {
+	if filePath == "" {
 		id := uuid.New().String()
 		filePath = "debug/Track-" + id + ".log"
 		fileName := "Track-" + id + ".log"
-		fmt.Printf("New File \"%s\" created in debug folder\n", fileName)
-	} else {
-		fmt.Scan(&filePath)
+		log.Printf("New File \"%s\" created in debug folder\n", fileName)
 	}
 	pathMap := lfshook.PathMap{
 		logrus.InfoLevel:  filePath,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,11 +13,13 @@ func NewLogger(filePath string) *logrus.Logger {
 	if Log != nil {
 		return Log
 	}
+	flag:=false
+	fileName:=""
 	if filePath == "" {
+		flag=true
 		id := uuid.New().String()
 		filePath = "debug/Track-" + id + ".log"
-		fileName := "Track-" + id + ".log"
-		log.Printf("New File \"%s\" created in debug folder\n", fileName)
+		fileName = "Track-" + id + ".log"
 	}
 	pathMap := lfshook.PathMap{
 		logrus.InfoLevel:  filePath,
@@ -35,5 +37,9 @@ func NewLogger(filePath string) *logrus.Logger {
 		pathMap,
 		&logrus.JSONFormatter{},
 	))
+    Log.Info("Started Execution")
+	if flag == true {
+    	log.Printf("New File \"%s\" created in debug folder\n", fileName)
+	}
 	return Log
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,46 @@
+package logger
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
+)
+
+var Log *logrus.Logger
+
+func NewLogger() *logrus.Logger {
+	if Log != nil {
+		return Log
+	}
+	var flag string
+	var filePath string
+	fmt.Println("Enter Path to log debug files: (Y/N)")
+	fmt.Scan(&flag)
+	if flag == "N" {
+		id := uuid.New().String()
+		filePath = "debug/Track-" + id + ".log"
+		fileName := "Track-" + id + ".log"
+		fmt.Printf("New File \"%s\" created in debug folder\n", fileName)
+	} else {
+		fmt.Scan(&filePath)
+	}
+	pathMap := lfshook.PathMap{
+		logrus.InfoLevel:  filePath,
+		logrus.ErrorLevel: filePath,
+		logrus.TraceLevel: filePath,
+		logrus.DebugLevel: filePath,
+		logrus.PanicLevel: filePath,
+		logrus.WarnLevel:  filePath,
+		logrus.FatalLevel: filePath,
+	}
+	Log = logrus.New()
+	Log.SetReportCaller(true)
+	Log.SetLevel(logrus.TraceLevel)
+	Log.Hooks.Add(lfshook.NewHook(
+		pathMap,
+		&logrus.JSONFormatter{},
+	))
+	return Log
+}

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -174,10 +174,6 @@ func (o *Orchestrator) addPairToTagMap(resource *tfjson.StateResource, tagToID m
 
 func main() {
     initializeLogger()
-	Log.Info("Hello Info")
-	Log.Warn("Hello Warn")
-
-	Log.WithField("int", 123).WithField("string", "haha").Error("Hello Error")
 	var orches Orchestrator
 	var persist Persistance
 	reccosFileName := "recos.txt"

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -8,10 +8,22 @@ import (
 	"os/exec"
 	"strings"
     "cloudfix-linter/logger"
+	"github.com/sirupsen/logrus"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-var log=logger.NewLogger()
+var Log *logrus.Logger
+
+func initializeLogger(){
+	var flag string
+	var filePath string
+	fmt.Println("Enter Path to log debug files: (Y/N)")
+	fmt.Scan(&flag)
+	if flag == "Y"{
+		fmt.Scan(&filePath)
+	}
+	Log = logger.NewLogger(filePath)
+}
 
 type Parameter struct {
 	IdealType      string `json:"Migrating to instance type"`
@@ -161,7 +173,11 @@ func (o *Orchestrator) addPairToTagMap(resource *tfjson.StateResource, tagToID m
 }
 
 func main() {
+    initializeLogger()
+	Log.Info("Hello Info")
+	Log.Warn("Hello Warn")
 
+	Log.WithField("int", 123).WithField("string", "haha").Error("Hello Error")
 	var orches Orchestrator
 	var persist Persistance
 	reccosFileName := "recos.txt"

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
+    "cloudfix-linter/logger"
 	tfjson "github.com/hashicorp/terraform-json"
 )
+
+var log=logger.NewLogger()
 
 type Parameter struct {
 	IdealType      string `json:"Migrating to instance type"`


### PR DESCRIPTION
Added logger initialization.
Initialization can be added by importing "cloudfix-linter/logger" to the file in which we have to log.
Used logrus which is a structured logger for go.
Link to repo: https://github.com/sirupsen/logrus

Specifications:
1). Logs User-facing logs to the console.
2). Logs all logs including debug logs to a separate log file. (By adding a unique ID to file name).
3). User-facing logs are written in text format.
4). Debug logs are written in structured JSON format.
5). Using only one command logger writes to both console as well as debug files.
6). User can override the path to the debug file in which debug logs should be written. 
7). A new debug log file is written per execution of the orchestrator and is not time based.
8). Both debug and user facing log would have timestamps, source file name and line numbers. 

How to use the logger: check above logrus repo link.