### PR TITLE
added tests for orchestrator

### DIFF
--- a/cloudfixManager_test.go
+++ b/cloudfixManager_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 )
 
-type Test struct {
+type TestReccoParser struct {
 	cloudfixReccos []byte
 	attrMapping    []byte
 	expected       map[string]map[string]string
 }
 
-var addTests = []Test{
+var addTestsReccos = []TestReccoParser{
 	{
 		// Test 1 : All known oppurtunity types with both dynamic and static ideal attribute values
 		[]byte(`[
@@ -373,7 +373,7 @@ var addTests = []Test{
 func TestParseReccos(t *testing.T) {
 
 	var cloudfixMan CloudfixManager
-	for _, test := range addTests {
+	for _, test := range addTestsReccos {
 		expected := test.expected
 		got := cloudfixMan.createMap(test.cloudfixReccos, test.attrMapping)
 		eq := reflect.DeepEqual(got, expected)

--- a/orchestrator.go
+++ b/orchestrator.go
@@ -25,6 +25,10 @@ func (o *Orchestrator) extractModulePaths(jsonString []byte) ([]string, error) {
 		Structure: "map(key->string,value->(array of map(key->string,value->interface))"
 	*/
 	var result map[string][]map[string]interface{}
+	if len(jsonString) == 0 {
+		//Empty string has been sent. No modules present
+		return modulePaths, nil
+	}
 	err := json.Unmarshal(jsonString, &result)
 	if err != nil {
 		//appLogger.Error().Println("Failed to unmarshall module paths from json string")

--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type ReturnByModuleParser struct {
+	modules []string
+}
+
+type TestModuleParser struct {
+	moduleJson []byte
+	expected   ReturnByModuleParser
+}
+
+var addTestsModules = []TestModuleParser{
+	{ // Test 1: Everything normal
+		[]byte(`{
+			"issues": [
+				{
+					"rule": {
+						"name": "module_source",
+						"severity": "info",
+						"link": ""
+					},
+					"message": ".//module-1",
+					"range": {
+						"filename": "main.tf",
+						"start": {
+							"line": 84,
+							"column": 23
+						},
+						"end": {
+							"line": 84,
+							"column": 36
+						}
+					},
+					"callers": []
+				},
+				{
+					"rule": {
+						"name": "module_source",
+						"severity": "info",
+						"link": ""
+					},
+					"message": ".//module-2",
+					"range": {
+						"filename": "main.tf",
+						"start": {
+							"line": 89,
+							"column": 12
+						},
+						"end": {
+							"line": 89,
+							"column": 25
+						}
+					},
+					"callers": []
+				}
+			],
+			"errors": []
+		}`),
+		ReturnByModuleParser{
+			[]string{".//module-1", ".//module-2"},
+		},
+	},
+	{ // Test 2: Empty JSON returned
+		[]byte(``),
+		ReturnByModuleParser{
+			[]string{},
+		},
+	},
+}
+
+func TestExtractModules(t *testing.T) {
+	var orches Orchestrator
+	for _, test := range addTestsModules {
+		expected := test.expected
+		modules, _ := orches.extractModulePaths(test.moduleJson)
+		if len(expected.modules) == 0 && len(modules) == 0 {
+			continue
+		}
+		eq := reflect.DeepEqual(ReturnByModuleParser{modules}, expected)
+		if !eq {
+			fmt.Println(expected)
+			fmt.Println(ReturnByModuleParser{modules})
+			t.Errorf("Test failed!")
+		}
+	}
+}


### PR DESCRIPTION
Have added tests for parsing the module paths. 

Two tests have been added, one where TfLint returns data, and one where it does not return anything. 